### PR TITLE
modified_stop_statements

### DIFF
--- a/src/METISSE_deltat.f90
+++ b/src/METISSE_deltat.f90
@@ -99,7 +99,7 @@
 !            if (id ==1)print*,'timestep',dt,dtr,t% pars% dt,t% times(4),age, t% pars% phase,id
 
             if (t% pars% dt<=0.0 .and. t% ierr==0) then
-                write(UNIT=err_unit,fmt=*)"fatal error: invalid timestep", t% pars% dt ,"for phase and id", t% pars% phase,id
+                write(UNIT=err_unit,fmt=*)"Fatal error: invalid timestep", t% pars% dt ,"for phase and id", t% pars% phase,id
                 write(UNIT=err_unit,fmt=*)"zams_mass, pars% mass, nuc_time, age, dt,dtr"
                 write(UNIT=err_unit,fmt=*)t% zams_mass, t% pars% mass,t% nuc_time, age, dt,dtr
                 t% ierr = -1
@@ -108,5 +108,7 @@
 !               call stop_code
             endif
             
+            if(t% ierr<0) code_error = .true.
+
             nullify(t)
       end subroutine METISSE_deltat

--- a/src/METISSE_hrdiag.f90
+++ b/src/METISSE_hrdiag.f90
@@ -44,8 +44,6 @@
     dt_hold = aj - t% pars% age
     if (aj/=aj) aj = t% pars% age
     t% pars% age = aj
-!    if (aj<0.d0) stop
-    
     
     IF (t% pars% phase<=TPAGB) THEN
         if (t% post_agb) then
@@ -253,8 +251,12 @@
     t% pars% rcenv = renv
 !    t% pars% env_frac = (mt-t% pars% McHe)/mt
 
-    if (debug) print*,"finished hrdiag",mt,mc,aj,kw,id,tm,tn
+    if(t% ierr<0) code_error = .true.
+    if(code_error) t% ierr = -1
+    
+    if(debug) print*,"finished hrdiag",mt,mc,aj,kw,id,tm,tn
 !    if (id==1)print*,"finished hrdiag",t% pars% mass, t% pars% core_mass,t% pars% age,t% pars% radius,id
 
+    
     nullify(t)
     end subroutine METISSE_hrdiag

--- a/src/METISSE_miscellaneous.f90
+++ b/src/METISSE_miscellaneous.f90
@@ -8,7 +8,7 @@ subroutine initialize_front_end(front_end_name)
     use track_support
     character (len=*), intent(in) :: front_end_name
 
-!    print*, 'in front end',trim(front_end_name)
+    if (verbose)print*, 'Setting front end to',trim(front_end_name)
 
     if (ANY((/'MAIN','main'/)== trim(front_end_name))) then
         ! METISSE's main code as described in Agrawal et al. 2020
@@ -28,7 +28,6 @@ subroutine initialize_front_end(front_end_name)
     else
         print*, "Error: Unrecongnized front_end_name for METISSE"
         print*, "Choose from 'MAIN', 'SSE', 'BSE', 'COSMIC' "
-        STOP
     endif
     
 end subroutine initialize_front_end

--- a/src/METISSE_star.f90
+++ b/src/METISSE_star.f90
@@ -258,6 +258,8 @@ subroutine METISSE_star(kw,mass,mt,tm,tn,tscls,lums,GB,zpars,dtm,id)
     t% MS_time = tm
     t% nuc_time = tn
 
+    if(t% ierr<0) code_error = .true.
+
     if (debug)print*, "in star end", mt,delta,kw,tm,tn,t%initial_mass,t% zams_mass
     if (debug) print*, '-----------------------------'
 

--- a/src/assign_commons_main.f90
+++ b/src/assign_commons_main.f90
@@ -15,7 +15,7 @@ subroutine assign_commons_main()
         else
             print*,"Error: Invalid Option for WD_mass_scheme."
             print*,"Choose from 'Mestel' and 'Modified_mestel'. "
-            STOP
+            call stop_code
         endif
 
         if (BHNS_mass_scheme == 'original_SSE') then
@@ -29,7 +29,7 @@ subroutine assign_commons_main()
         else
             print*,"Error: Invalid Option for BHNS_mass_scheme."
             print*,"Choose from 'original_SSE','Belczynski2002','Belczynski2008','Eldridge_Tout2004'. "
-            STOP
+            call stop_code
         endif
         !call cutoffs_for_Belzynski_methods(ns_flag,mc1,mc2)
 

--- a/src/interp_support.f90
+++ b/src/interp_support.f90
@@ -34,7 +34,7 @@ module interp_support
         if (mass/=mass .or. mass<=0.d0) then
             write(UNIT=err_unit,fmt=*)"Fatal Error: Invalid mass",mass,t% pars% phase
             t% ierr = -1
-!            call stop_code
+!            call stop_code(err_unit)
             return
         endif
         
@@ -522,7 +522,7 @@ module interp_support
                 start = start-1
                 if (start <1)  then
                     write(UNIT=err_unit,fmt=*)"Error in mod_PAV, start<1",i,n
-!                    call stop_code
+!                    call stop_code(err_unit)
                 endif
             end do
             if (debug) print*,'start, old_start', start, old_start
@@ -683,7 +683,7 @@ module interp_support
                         write(UNIT=err_unit,fmt=*) 'Warning: NaN encountered during interpolation age',&
                             t% initial_mass,input_age,j,mhi,mlo,t% pars% phase
                         t% ierr = -1
-            !            call stop_code
+            !            call stop_code(err_unit)
                         return
                     endif
                 end do
@@ -698,7 +698,7 @@ module interp_support
 
                 if (age< x(2) .or. age> x(3)) then
                    write(UNIT=err_unit,fmt=*)"Error in cubic interpolation in interp_support"
-!                   call stop_code
+!                   call stop_code(err_unit)
                 endif
 
                 do j = jstart,jend
@@ -725,7 +725,7 @@ module interp_support
 
         if (t% pars% mass <0.0) then
             write(UNIT=err_unit,fmt=*)"Fatal Error: mass <0 in interpolate age",input_age,t% pars% phase
-!            call stop_code
+!            call stop_code(err_unit)
         endif
         if (debug) print*, 'exiting interpolate_age'
         

--- a/src/main_metisse.f90
+++ b/src/main_metisse.f90
@@ -14,9 +14,13 @@ program metisse_main
 
     !set the front end for METISSE
     call initialize_front_end('main')
-    initial_z = -1.d0
-    !read files of input metallicity and load them
-    call METISSE_zcnsts(initial_Z,zpars,'','')
+    
+    initial_Z = -1.d0
+    
+    ! read input metallicity and load the crresponding EEP tracks
+    ! path for tracks are read from inlists
+    call METISSE_zcnsts(initial_Z,zpars,'','',ierr)
+    if (ierr/=0) STOP 'Fatal error: terminating METISSE'
     
     ! sets remnant schmeme from SSE_input_controls
     call assign_commons_main()
@@ -27,19 +31,20 @@ program metisse_main
     if (read_mass_from_file) then
         !reads mass and age values from path for mass_file
         open(101, FILE= trim(input_mass_file), action="read",iostat =ierr)
-            do i=1,number_of_tracks
-                read(101,*) mass_array(i)
-            end do
-         close(101)
-
+        
         if (ierr/=0) then
             print*,'Erorr reading input masses from', trim(input_mass_file)
             print*,'check if input_mass_file is correct'
-            call stop_code
+            STOP 'Fatal error: terminating METISSE'
         endif
+        
+        do i=1,number_of_tracks
+            read(101,*) mass_array(i)
+        end do
+        close(101)
     else
         if (number_of_tracks>1) then
-            call uniform_distribution (number_of_tracks, min_mass, max_mass, mass_array)
+            call uniform_distribution(number_of_tracks,min_mass,max_mass,mass_array)
         else
             mass_array = min_mass
         endif

--- a/src/remnant_support.f90
+++ b/src/remnant_support.f90
@@ -35,8 +35,7 @@
 
         debug_rem = .false.
         check_remnant_phase = .false.
-        !mcmax1 = 0.d0
-    
+        
         mc_threshold = pars% core_mass
         
         if (pars% phase <= TPAGB) then       !without envelope loss
@@ -49,11 +48,15 @@
             return
         endif
 
-        if (mc_max<=0.0) then
-            write(UNIT=err_unit,fmt=*)"Fatal error: negative mc_max ", mc_max
-            call stop_code
+        if (mc_max<=0.d0 .or. mc_threshold<=0.d0) then
+            write(UNIT=err_unit,fmt=*)"Fatal error: non-positive core mass",mc_max, mc_threshold
+            code_error = .true.
+            !assigning an ad-hoc non-zero core mass so the code doesn't break
+            !TODO: fix very low-mass stars that form hewd and may get caught in this
+            mc_threshold = 0.7*pars% McHe
+            mc_max = mc_threshold
         endif
-
+        
         if(mc_threshold>=mc_max .or. abs(mc_max-mc_threshold)<tiny .or. end_of_file)then
             !mc = MIN(mc_max,mc_threshold)
             pars% core_mass = mc_threshold

--- a/src/track_support.f90
+++ b/src/track_support.f90
@@ -231,7 +231,8 @@ module track_support
     type(track), allocatable, target :: sa(:), sa_he(:)
     type(track), allocatable, target :: tarr(:)
     real(dp) :: initial_Z
-
+    logical :: code_error
+    
     !variable declaration-- for main
     integer :: number_of_tracks
     character(len=strlen) :: input_mass_file
@@ -385,10 +386,14 @@ module track_support
         endif
     end function binary_search
     
-    subroutine stop_code()
-        print*, 'Error encountered; stopping METISSE'
-        print*, 'See error file (fort.99) or terminal for details'
-        STOP
+    subroutine stop_code(i)
+        integer, optional:: i
+        print*, 'Fatal error: terminating METISSE'
+        if (present(i)) then
+            if (i==5) print*, 'See terminal for details'
+            if (i==99) print*, 'See error file (fort.99)for details'
+        endif
+        if (front_end /=COSMIC) STOP
     end subroutine stop_code
     
     subroutine write_eep_track(x,mt,filename)


### PR DESCRIPTION
When calling Fortran from Python, if Fortran code stops for some reason, the Python part doesn't stop by itself. Instead, it waits patiently for Fortran to return something (until the user's patience runs out or the code's runtime). With this pull request, METISSE now sends an error message back to Python when a Fatal Error occurs in zcnsts.f. 