### PR TITLE
corrected age for wind calc. and interp of very low-mass stars

### DIFF
--- a/src/METISSE_mlwind.f90
+++ b/src/METISSE_mlwind.f90
@@ -38,8 +38,8 @@ real(dp) function metisse_mlwind(kw,lum,r,mt,mc,rl,z,id)
         if (t% star_type == sse_he_star) then
             dms = SSE_mlwind(kw,lum,r,mt,mc,rl,z)
         else
-            tnext = t% pars% age2+ t% pars% dt
-            tprev = max(0.d0,t% pars% age2-t% pars% dt)
+            tnext = t% pars% age+ t% pars% dt
+            tprev = max(0.d0,t% pars% age-t% pars% dt)
 !        print*,'in mlwind',t% pars% age,t% pars% dt,tprev,tnext
             if (tprev<=0.d0) then
                 !Forward finite difference

--- a/src/interp_support.f90
+++ b/src/interp_support.f90
@@ -201,6 +201,15 @@ module interp_support
             iseg = size(cutoff)-1
             deallocate(cutoff); nullify(s)
             return
+        elseif(mass < s(1)% initial_mass*0.9) then
+            min_index = 1
+            keyword = no_interpolation
+            allocate(bounds(1))
+            bounds = min_index
+            if (debug_mass) print*,"No interpolation: mass below lowest initial mass, ",mass
+            iseg = 1
+            deallocate(cutoff); nullify(s)
+            return
         endif
             
         ! we don't want to search the whole list, only between the mass cutoffs


### PR DESCRIPTION
There was a leftover modification in the calculations of winds; age2 was getting used while all other calculations are based on the age of the star; fixed that. An interpolation criterion was added that does not allow extrapolation below 0.99 of the lowest mass star in the input set. 
