### PR TITLE
change common envelope binding energy calculation

### DIFF
--- a/src/comenv_lambda.f90
+++ b/src/comenv_lambda.f90
@@ -27,8 +27,12 @@ subroutine comenv_lambda(KW,M0,L,R,MENVD,LAMBDA,id,LAMBF)
     else
         RZAMS = 10.d0**t% tr(i_logR,ZAMS_EEP)
     endif
-                
-    LAMBF = CELAMF(KW,M0,L,R,RZAMS,MENVD,LAMBDA)
+    
+    if (i_binding_energy > 0) then
+        LAMBF = - (t% pars% mass * (t% pars% mass - t% pars% core_mass)) / (t% pars% binding_energy * R)
+    else
+        LAMBF = CELAMF(KW,M0,L,R,RZAMS,MENVD,LAMBDA)
+    endif
     !comenv_lambda = LAMBF
 
     nullify(t)


### PR DESCRIPTION
If `i_binding_energy` is found, use the binding energy interpolated from MESA track directly instead of calculating lambda using Claeys+ appendix. Change made is in `comenv_lambda.f90`.