### PR TITLE
fixed a small bug related to length of the strings

### DIFF
--- a/metisse.input
+++ b/metisse.input
@@ -7,6 +7,8 @@ METALLICITY_DIR = '/Users/poojan/stellar_tracks/MESA/big_z/hydrogen'
             
 METALLICITY_DIR_HE = '/Users/poojan/stellar_tracks/MESA/big_z/helium'
 
+METALLICITY_DIR_HE = ''
+
 verbose = .true.
 
 /

--- a/src/METISSE_zcnsts.f90
+++ b/src/METISSE_zcnsts.f90
@@ -108,7 +108,7 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
         ! these file contain information about eep tracks, their metallicity
         ! and the format file
         
-        if (len(METALLICITY_DIR)< 1) then
+        if (len(trim(METALLICITY_DIR))< 1) then
             write(*,*) "METISSE error: METALLICITY_DIR/path_to_tracks is an empty string"
             ierr = 1
             return
@@ -126,7 +126,7 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             endif
         endif
         
-        if (len(METALLICITY_DIR_HE)< 1) then
+        if (len(trim(METALLICITY_DIR_HE))< 1) then
             write(out_unit,*) "Warning: METALLICITY_DIR_HE/path_to_he_tracks is an empty string"
             write(out_unit,*) "Switching to SSE formulae for helium stars "
             nloop = 1

--- a/src/z_support.f90
+++ b/src/z_support.f90
@@ -260,7 +260,7 @@ module z_support
         
         ierr = 0
         
-        if (len(path) <1 )then
+        if (len(trim(path)) <1 )then
             ierr = 1; return
         endif
         
@@ -575,7 +575,7 @@ module z_support
 
         !now find the column
         locate_column = -1
-        if (len(colname)<1) return
+        if (len(trim(colname)<1)) return
         
         do i=1,size(cols)
            if(adjustl(adjustr(cols(i)% name))==trim(colname)) then


### PR DESCRIPTION
Due to a small issue related to checking the length of the strings, METISSE would look helium files even if they weren't supplied (instead of switching to SSE formulae), raise error and stop. fixed it now. 