### PR TITLE
fixed sorting algorithm for different file naming conventions

### DIFF
--- a/src/METISSE_zcnsts.f90
+++ b/src/METISSE_zcnsts.f90
@@ -260,6 +260,10 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
 
         ! Process the input tracks
         if (i==2) then
+            !sort the array based on intial mass if not sorted already
+            call sort_minitial()
+            !reset z parameters where available
+            !and determine cutoff masses
             call set_zparameters_he(num_tracks)
             call copy_and_deallocatex(num_tracks,sa_he)
             call get_minmax(sa_he(1)% is_he_track,Mmax_he_array,Mmin_he_array)
@@ -274,6 +278,8 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             core_cols_he(3) = i_co_core
             if (i_he_RCO>0) core_cols_he(4) = i_he_RCO
         else
+            !sort the array based on intial mass if not sorted already
+            call sort_minitial()
             !reset z parameters where available
             !and determine cutoff masses
             call set_zparameters(num_tracks,zpars)

--- a/src/z_support.f90
+++ b/src/z_support.f90
@@ -1139,8 +1139,6 @@ module z_support
 
         end do
         
-        !sort the array based on intial mass if not sorted already
-        call sort_minitial(y)
         !Now deallocate xa
         deallocate(xa)
         deallocate(key_cols)
@@ -1158,25 +1156,33 @@ module z_support
         endif
     end function
     
-    subroutine sort_minitial(y)
-        type(track):: y(:), temp
-        real(dp), allocatable :: list(:)
+    subroutine sort_minitial()
+        type(track):: temp
+        real(dp), allocatable :: list(:),d(:)
         integer :: i, a, loc, n
 
-        list = y% initial_mass
-        n = size(list)
+        n = size(xa)
+        allocate(list(n),d(n-1))
         
         !sort array and swap tracks where needed
+        do while (.true.)
+        list = xa% initial_mass
+        
+        d = list(2:n)-list(1:n-1)
+        if(all(d>=0)) exit !test for monotonicity
         do i = 1, n-1
             a = minloc(list(i:n),dim=1)
             loc = (i - 1) + a
             if (loc/=i) then
-                print*, 'swapping input tracks at',loc,i
-                temp = y(loc)
-                y(loc) = y(i)
-                y(i) = temp
+                if (debug_z)print*, 'swapping input tracks at',loc,i
+                temp = xa(loc)
+                xa(loc) = xa(i)
+                xa(i) = temp
             endif
         end do
+        end do
+        
+        deallocate(list,d)
     end subroutine sort_minitial
     
     subroutine get_minmax(is_he_track,Mmax,Mmin)


### PR DESCRIPTION
METISSE needs input tracks sorted in mass. 'find' command which is used to read filenames, doesn't sort them if they are of unequal size. there was a sorting method in place but not good enough. So now have modified the sorting method so it can recursively work until all files are sorted. 
