### PR TITLE
c and mpi compatability

### DIFF
--- a/src/METISSE_miscellaneous.f90
+++ b/src/METISSE_miscellaneous.f90
@@ -32,6 +32,11 @@ subroutine initialize_front_end(front_end_name)
     
 end subroutine initialize_front_end
 
+subroutine set_file_mode(i)
+    use track_support, only: mode
+    integer, intent(in) :: i
+    mode = i
+end subroutine
 
 subroutine allocate_track(n,mass)
     use track_support

--- a/src/METISSE_miscellaneous.f90
+++ b/src/METISSE_miscellaneous.f90
@@ -8,7 +8,7 @@ subroutine initialize_front_end(front_end_name)
     use track_support
     character (len=*), intent(in) :: front_end_name
 
-    if (verbose)print*, 'Setting front end to',trim(front_end_name)
+    if (verbose)print*, 'Setting front end to ',trim(front_end_name)
 
     if (ANY((/'MAIN','main'/)== trim(front_end_name))) then
         ! METISSE's main code as described in Agrawal et al. 2020

--- a/src/METISSE_zcnsts.f90
+++ b/src/METISSE_zcnsts.f90
@@ -21,7 +21,6 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
     ! decide how to deal with errors.
 
     code_error = .false.
-    nloop = 2    ! read both hydrogen and helium tracks by default
     
     if (front_end <0) then
         print*, 'METISSE error: front_end is not initialized'
@@ -32,6 +31,7 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
     
     ! read one set of stellar tracks (of input Z)
     load_tracks = .false.
+    use_sse_NHe = .false.
     
     if (allocated(sa) .eqv. .true.) then
         ! tracks have been loaded at least once, for initial_Z
@@ -136,7 +136,7 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
         if (len(trim(METALLICITY_DIR_HE))< 1) then
             write(out_unit,*) "Warning: METALLICITY_DIR_HE/path_to_he_tracks is an empty string"
             write(out_unit,*) "Switching to SSE formulae for helium stars "
-            nloop = 1
+            use_sse_NHe = .true.
         else
             temp_filename  = '.Zfilenames_He.txt'
             call get_metallicity_file_list(METALLICITY_DIR_HE,metallicity_file_list_he,temp_filename)
@@ -155,8 +155,14 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
     
     if (front_end /= main) initial_Z = z
     write(out_unit,'(a,1p1e13.5)') ' Input Z is :', z
-    
-    use_sse_NHe = .true.
+
+    if (use_sse_NHe)then
+        ! only read hydrogen tracks
+        nloop = 1
+    else
+        ! read both hydrogen and helium tracks
+        nloop = 2
+    endif
 
     ! need to intialize these seperately as they may be
     ! used uninitialized if he tracks are not present
@@ -175,10 +181,11 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
                 write(out_unit,'(a,1p1e13.5)')" No matching Z_files found with Z_accuracy_limit =",Z_accuracy_limit
                 write(out_unit,*)"Switching to SSE formulae for helium stars "
                 ierr = 0
+                use_sse_NHe = .true.
                 cycle
             endif
             write(out_unit,'(a,1p1e13.5)')" Found matching Z_files ",initial_Z
-
+          
             USE_DIR = METALLICITY_DIR_HE
             temp_filename = '.Mfilenames_He.txt'
 
@@ -274,8 +281,6 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             call set_zparameters_he(num_tracks)
             call copy_and_deallocatex(num_tracks,sa_he)
             call get_minmax(sa_he(1)% is_he_track,Mmax_he_array,Mmin_he_array)
-
-            use_sse_NHe = .false.
             if (allocated(core_cols_he)) deallocate(core_cols_he)
 
             allocate(core_cols_he(4))

--- a/src/METISSE_zcnsts.f90
+++ b/src/METISSE_zcnsts.f90
@@ -9,13 +9,11 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
     
     character(LEN=strlen), allocatable :: track_list(:)
     character(LEN=strlen) :: USE_DIR, find_cmd, rnd, infile, temp_filename
-    integer :: i,j,nloop
-    integer :: num_tracks
+    integer :: i,j,nloop, num_tracks
     logical :: load_tracks, debug
     
     debug = .false.
     ierr = 0
-    mode = 0
     ! At this point in the code front_end might not be assigned
     ! So we return ierr and let zcnsts.f of the overlying code
     ! decide how to deal with errors.
@@ -88,8 +86,8 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             call read_metisse_input(infile,ierr)
             if (ierr/=0) call stop_code
         case(COSMIC)
-            METALLICITY_DIR = path_to_tracks
-            METALLICITY_DIR_HE = path_to_he_tracks
+             call get_csafe_string(path_to_tracks,METALLICITY_DIR)
+             call get_csafe_string(path_to_he_tracks,METALLICITY_DIR_HE)
         case default
             print*, "METISSE error: reading inputs; unrecognized front_end_name"
             ierr = 1; return

--- a/src/METISSE_zcnsts.f90
+++ b/src/METISSE_zcnsts.f90
@@ -8,14 +8,14 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
     integer, intent(out) :: ierr
     
     character(LEN=strlen), allocatable :: track_list(:)
-    character(LEN=strlen) :: USE_DIR, find_cmd, rnd, infile
+    character(LEN=strlen) :: USE_DIR, find_cmd, rnd, infile, temp_filename
     integer :: i,j,nloop
     integer :: num_tracks
     logical :: load_tracks, debug
     
     debug = .false.
     ierr = 0
-    
+    mode = 0
     ! At this point in the code front_end might not be assigned
     ! So we return ierr and let zcnsts.f of the overlying code
     ! decide how to deal with errors.
@@ -50,7 +50,13 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             (trim(path_to_he_tracks)/=trim(METALLICITY_DIR_HE))) load_tracks = .true.
         endif
         
-        if (load_tracks.eqv. .false.) then
+        if (load_tracks) then
+            if (mode/=0) then
+              print*, 'METISSE error: cannot change path or metallicity mid-run when using mpi'
+              ierr = 1
+              return
+            endif
+        else
             if (debug) print*, 'No change in metallicity or paths, exiting METISSE_zcnsts',initial_Z,z
             return
         endif
@@ -113,10 +119,11 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             ierr = 1
             return
         else
-            call get_metallicity_file_list(METALLICITY_DIR,metallicity_file_list)
+            temp_filename = '.Zfilenames_H.txt'
+            call get_metallicity_file_list(METALLICITY_DIR,metallicity_file_list,temp_filename)
                 
             if (.not. allocated(metallicity_file_list)) then
-                write(*,*) "METISSE error: metallicity file(s) not found in", trim(METALLICITY_DIR)
+                write(*,*) "METISSE error: metallicity file(s) not found in ", trim(METALLICITY_DIR)
                 write(*,*) "check if METALLICITY_DIR/path_to_tracks is correct"
                 ierr = 1
                 return
@@ -131,10 +138,11 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             write(out_unit,*) "Switching to SSE formulae for helium stars "
             nloop = 1
         else
-            call get_metallicity_file_list(METALLICITY_DIR_HE,metallicity_file_list_he)
+            temp_filename  = '.Zfilenames_He.txt'
+            call get_metallicity_file_list(METALLICITY_DIR_HE,metallicity_file_list_he,temp_filename)
 
             if (.not. allocated(metallicity_file_list_he)) then
-                write(*,*) "METISSE error: metallicity file(s) not found in", trim(METALLICITY_DIR_HE)
+                write(*,*) "METISSE error: metallicity file(s) not found in ", trim(METALLICITY_DIR_HE)
                 write(*,*) "check if METALLICITY_DIR_HE/path_to_he_tracks is correct"
                 ierr = 1
                 return
@@ -172,6 +180,8 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             write(out_unit,'(a,1p1e13.5)')" Found matching Z_files ",initial_Z
 
             USE_DIR = METALLICITY_DIR_HE
+            temp_filename = '.Mfilenames_He.txt'
+
         else
             write(out_unit,*) 'Reading main (hydrogen star) tracks'
             call get_metallcity_file_from_Z(metallicity_file_list,Z_H,initial_Z,ierr)
@@ -184,6 +194,7 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
 
             write(out_unit,'(a,1p1e13.5)')" Found matching Z_files ",initial_Z
             USE_DIR = METALLICITY_DIR
+            temp_filename = '.Mfilenames_H.txt'
         endif
         
         !read file-format
@@ -191,11 +202,11 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             
         !get filenames from eep_tracks_dir
         if (read_eep_files) file_extension = '.eep'
-        call get_files_from_path(eep_tracks_dir,file_extension,track_list,ierr)
+        call get_files_from_path(eep_tracks_dir,file_extension,temp_filename,track_list,ierr)
         
         if (ierr/=0) then
             eep_tracks_dir = trim(USE_DIR)//'/'//trim(eep_tracks_dir)
-            call get_files_from_path(eep_tracks_dir,file_extension,track_list,ierr)
+            call get_files_from_path(eep_tracks_dir,file_extension,temp_filename,track_list,ierr)
         endif
         
         if (ierr/=0 ) then

--- a/src/track_support.f90
+++ b/src/track_support.f90
@@ -29,7 +29,10 @@ module track_support
     integer, parameter :: main = 0
     integer, parameter :: BSE = 1
     integer, parameter :: COSMIC = 2
-
+    
+    ! mode >0 enables read-only mode for files when multi-threading
+    integer :: mode = 0
+    
     character(len=strlen) :: METISSE_DIR,METALLICITY_DIR,METALLICITY_DIR_HE
 
     ! for use when constructing EEP distance

--- a/src/z_support.f90
+++ b/src/z_support.f90
@@ -4,7 +4,7 @@ module z_support
 
     character(LEN=strlen) :: eep_tracks_dir
     logical :: read_eep_files, read_all_columns, get_cols
-
+    
     integer :: max_files = 50
     character(LEN=strlen) :: format_file, extra_columns_file
     character(LEN=strlen), allocatable :: metallicity_file_list(:),metallicity_file_list_he(:)
@@ -18,7 +18,6 @@ module z_support
     character(LEN=strlen) :: column_name_file
     type(column), allocatable :: key_cols(:), temp_cols(:)
     integer :: total_cols
-
     character:: extra_char
 
     type(track), allocatable :: xa(:)
@@ -33,6 +32,7 @@ module z_support
     real(dp) :: he_core_mass_limit = 2.2d0 !Msun
 
     logical :: debug_z
+
 
     namelist /SSE_input_controls/ initial_Z, max_age,read_mass_from_file,&
                         input_mass_file, number_of_tracks, max_mass, min_mass, &
@@ -66,6 +66,7 @@ module z_support
         !path is relative to the executable
         METISSE_DIR = '.'
         include 'defaults/metisse_defaults.inc'
+        
     end subroutine read_defaults
     
     subroutine read_main_input(infile,ierr)
@@ -109,19 +110,17 @@ module z_support
     end subroutine read_metisse_input
     
     
-    subroutine get_metallicity_file_list(path,file_list)
-        character(LEN=strlen) :: path
+    subroutine get_metallicity_file_list(path,file_list,filename)
+        character(LEN=strlen) :: path, filename
         character(LEN=strlen), allocatable :: temp_list(:),file_list(:)
         integer :: ierr, n
 
         if (allocated(file_list)) deallocate(file_list)
         ierr = 0
         
-        call get_files_from_path(path,'_metallicity.in',temp_list,ierr)
+        call get_files_from_path(path,'_metallicity.in',filename,temp_list,ierr)
         if (.not. allocated(temp_list)) then
-            print*, 'Could not find metallicity file(s) in ',trim(path)
-            ierr = 1
-            return
+            ierr = 1; return
         endif
         
         n = size(temp_list)
@@ -249,32 +248,40 @@ module z_support
 
     end subroutine read_format
 
-    subroutine get_files_from_path(path,extension,file_list,ierr)
-        character(LEN=strlen), intent(in) :: path
+    subroutine get_files_from_path(path,extension,filename,list,ierr)
+        character(LEN=strlen), intent(in) :: path,  filename
+
         character(LEN=*), intent(in) :: extension
-        character(LEN=strlen), allocatable :: file_list(:)
+        
+        character(LEN=strlen), allocatable :: list(:)
         integer, intent(out) ::  ierr
 
         character(LEN=strlen) :: str,cmd
-        integer :: n,i, io,isize
+        integer :: n,i, io, iosize
         
         ierr = 0
         
-        if (len(trim(path)) <1 )then
-            ierr = 1; return
+        if (mode ==0) then
+        
+            if (path=='' .or. filename == '')then
+                ierr = 1; return
+            endif
+            
+            cmd = 'find '//trim(path)//'/*'//trim(extension)//' -maxdepth 1 > ' //trim(filename)// ' 2> .error.txt'
+            
+            call system(cmd,ierr)
+            if (ierr/=0) return
+
+            inquire(file='.error.txt', size=iosize)
+            if (iosize>0)then
+                ierr = 1; return
+            endif
+        
         endif
         
-        cmd = 'find '//trim(path)//'/*'//trim(extension)//' -maxdepth 1 > .file_name.txt 2> .error.txt'
-        call system(cmd,ierr)
-        if (ierr/=0) return
-
-        inquire(file='.error.txt', size=isize)
-        if (isize>0)then
-            ierr = 1; return
-        endif
-
+        
         io = alloc_iounit(ierr)
-        open(io,FILE='.file_name.txt',action="read")
+        open(io,FILE=trim(filename),status = "old", action="read")
 
         !count the number of tracks
         n = 0
@@ -284,14 +291,16 @@ module z_support
             n = n+1
         end do
 
-        allocate(file_list(n))
+        allocate(list(n))
         rewind(io)
         ierr = 0
         do i = 1,n
             read(io,'(a)',iostat=ierr)str
             if (ierr/=0) exit
-            file_list(i) = trim(str)
+            list(i) = trim(str)
         end do
+        
+        
         close(io)
         call free_iounit(io)
     end subroutine get_files_from_path

--- a/src/z_support.f90
+++ b/src/z_support.f90
@@ -250,39 +250,33 @@ module z_support
 
     subroutine get_files_from_path(path,extension,filename,list,ierr)
         character(LEN=strlen), intent(in) :: path,  filename
-
         character(LEN=*), intent(in) :: extension
-        
         character(LEN=strlen), allocatable :: list(:)
         integer, intent(out) ::  ierr
-
-        character(LEN=strlen) :: str,cmd
+        character(LEN=512) :: str,cmd
         integer :: n,i, io, iosize
-        
+        logical :: exists
         ierr = 0
-        
         if (mode ==0) then
-        
             if (path=='' .or. filename == '')then
                 ierr = 1; return
             endif
+            ! remove any pre-existing file to avoid contamination'
+            inquire(file=trim(filename), exist=exists)
+            cmd  = 'rm '//trim(filename)
+            if (exists) call system (cmd)
             
             cmd = 'find '//trim(path)//'/*'//trim(extension)//' -maxdepth 1 > ' //trim(filename)// ' 2> .error.txt'
-            
             call system(cmd,ierr)
             if (ierr/=0) return
-
             inquire(file='.error.txt', size=iosize)
             if (iosize>0)then
                 ierr = 1; return
             endif
-        
         endif
-        
         
         io = alloc_iounit(ierr)
         open(io,FILE=trim(filename),status = "old", action="read")
-
         !count the number of tracks
         n = 0
         do while(.true.)
@@ -299,12 +293,24 @@ module z_support
             if (ierr/=0) exit
             list(i) = trim(str)
         end do
-        
-        
         close(io)
         call free_iounit(io)
     end subroutine get_files_from_path
 
+    subroutine get_csafe_string(cstring, fstring)
+        integer :: inull
+        character(LEN=*), intent(in) :: cstring
+        character(LEN=strlen), intent(out) ::  fstring
+
+        inull = index(cstring, char(0))
+        if (inull>0) then
+            fstring = adjustl((cstring(1:inull-1)))
+        else
+            fstring = trim(cstring)
+        endif
+            
+    end subroutine
+    
     subroutine read_eep(x)
         !adapted from iso/iso_eep_support.f90
         type(track), intent(inout) :: x


### PR DESCRIPTION
Added the ability to read strings directly from c codes (CMC) and enable read-only mode for slave threads when using mpi to avoid race conditions. 