### PR TITLE
Cosmic inputs

### DIFF
--- a/make/makefile
+++ b/make/makefile
@@ -36,7 +36,7 @@ interp_support.o: $(METISSE_src_dir)/interp_support.f90 track_support.o
 sse_support.o: $(METISSE_src_dir)/sse_support.f90 track_support.o
 remnant_support.o: $(METISSE_src_dir)/remnant_support.f90 track_support.o sse_support.o
 
-assign_commons.o: $(METISSE_src_dir)/assign_commons_bse.f90 track_support.o remnant_support.o
+assign_commons.o: $(METISSE_src_dir)/assign_commons_other.f90 track_support.o remnant_support.o
 METISSE_miscellaneous.o: $(METISSE_src_dir)/METISSE_miscellaneous.f90 track_support.o
 comenv_lambda.o: $(METISSE_src_dir)/comenv_lambda.f90 track_support.o
 

--- a/src/METISSE_zcnsts.f90
+++ b/src/METISSE_zcnsts.f90
@@ -1,9 +1,8 @@
-subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
+subroutine METISSE_zcnsts(z,zpars,ierr)
     use track_support
     use z_support
 
     real(dp), intent(in) :: z
-    character(len=*), intent(in) :: path_to_tracks, path_to_he_tracks
     real(dp), intent(out) :: zpars(20)
     integer, intent(out) :: ierr
     
@@ -25,7 +24,7 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
         ierr = 1; return
     endif
     
-    if (debug) print*, 'in METISSE_zcsnts',z, trim(path_to_tracks),trim(path_to_he_tracks)
+    if (debug) print*, 'in METISSE_zcsnts',z
     
     ! read one set of stellar tracks (of input Z)
     load_tracks = .false.
@@ -43,11 +42,8 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
         ! Currently only for cosmic, as it can change path_to_tracks mid-computation
         ! through its python wrapper
         
-        if (front_end == COSMIC)then
-            if((trim(path_to_tracks)/=trim(METALLICITY_DIR)) .or. &
-            (trim(path_to_he_tracks)/=trim(METALLICITY_DIR_HE))) load_tracks = .true.
-        endif
-        
+        if (front_end == COSMIC) call check_path_change(load_tracks)
+    
         if (load_tracks) then
             if (mode/=0) then
               print*, 'METISSE error: cannot change path or metallicity mid-run when using mpi'
@@ -86,8 +82,7 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             call read_metisse_input(infile,ierr)
             if (ierr/=0) call stop_code
         case(COSMIC)
-             call get_csafe_string(path_to_tracks,METALLICITY_DIR)
-             call get_csafe_string(path_to_he_tracks,METALLICITY_DIR_HE)
+             call get_COSMIC_input()
         case default
             print*, "METISSE error: reading inputs; unrecognized front_end_name"
             ierr = 1; return
@@ -191,9 +186,9 @@ subroutine METISSE_zcnsts(z,zpars,path_to_tracks,path_to_he_tracks,ierr)
             write(out_unit,*) 'Reading main (hydrogen star) tracks'
             call get_metallcity_file_from_Z(metallicity_file_list,Z_H,initial_Z,ierr)
             if (ierr/=0) then
-                write(out_unit,'(a,1p1e13.5)')" No matching Z_files found with Z_accuracy_limit =",Z_accuracy_limit
-                write(out_unit,*)"If needed, Z_accuracy_limit can be increased to match one of the available Z_files "
-                write(out_unit,'(1p100e13.5)') pack(Z_H, mask = Z_H>0)
+                write(*,'(a,1p1e13.5)')" No matching Z_files found with Z_accuracy_limit =",Z_accuracy_limit
+                write(*,*)"If needed, Z_accuracy_limit can be increased to match one of the available Z_files "
+                write(*,'(1p100e13.5)') pack(Z_H, mask = Z_H>0)
                 return
             endif
 

--- a/src/assign_commons_other.f90
+++ b/src/assign_commons_other.f90
@@ -1,4 +1,13 @@
 subroutine assign_commons()
-        ! dummy file
-    end subroutine
+    ! dummy for compilation
+    ! actual subroutine should be in overlying code's directory
+end subroutine
 
+subroutine get_COSMIC_input()
+    ! dummy for compilation
+    ! actual subroutine is in cosmic/assign_common_cosmic.f90
+end subroutine
+
+logical function check_path_change() result (load_tracks)
+    load_tracks = .true.
+end function

--- a/src/main_metisse.f90
+++ b/src/main_metisse.f90
@@ -19,7 +19,7 @@ program metisse_main
     
     ! read input metallicity and load the crresponding EEP tracks
     ! path for tracks are read from inlists
-    call METISSE_zcnsts(initial_Z,zpars,'','',ierr)
+    call METISSE_zcnsts(initial_Z,zpars,ierr)
     if (ierr/=0 .or. code_error) STOP 'Fatal error: terminating METISSE'
     
     ! sets remnant schmeme from SSE_input_controls

--- a/src/z_support.f90
+++ b/src/z_support.f90
@@ -308,7 +308,6 @@ module z_support
         else
             fstring = trim(cstring)
         endif
-            
     end subroutine
     
     subroutine read_eep(x)


### PR DESCRIPTION
**Important: This update modifies calls to zcnsts.f for any code using METISSE**

Major change in how inputs for METISSE are handled: **`paths_to_track` and `paths_to_he_track` are no longer passed as variables when calling zcnsts.** 
This update makes it easier for any code to assign values to metisse variables with just their own input files.
For example , in COSMIC `paths_to_track`,`paths_to_he_track` and two more variables: `z_match limit` (which lets users decide how close they want to sample metallicity), and `METISSE_verbose` have been added to a common block  METISSEVARS in const_bse.h. 
They get assigned proper variable names in METISSE through `get_COSMIC_input` subroutine defined in METISSE_utils.f90 (located in the COSMIC's source folder).


