### PR TITLE
Add Check in METISSE_zcnsts to force track reading if zpars is a zero-valued array

### DIFF
--- a/src/METISSE_zcnsts.f90
+++ b/src/METISSE_zcnsts.f90
@@ -36,6 +36,7 @@ subroutine METISSE_zcnsts(z,zpars,ierr)
         ! New tracks need to be loaded
         ! if input metallicity 'z' has changed significantly from the old 'initial_z'
         if (relative_diff(initial_Z,z) .ge. Z_accuracy_limit) load_tracks = .true.
+        if (all(abs(zpars) == 0.d0)) load_tracks = .true.
 
         ! or maybe metallicity is the same, but paths may have changed
         ! (for example, for sets of tracks computed with different stellar parameters)


### PR DESCRIPTION
Hello!

This PR is one line, and all it does is add a check in `METISSE_zcnsts` to see if `zpars` is all zero-valued. If this is true, it reloads tracks to obtain `zpars` again. When using COSMIC as a front-end METISSE only loads tracks once, but subsequent calls to Evolve.evolve will preserve the track and not `zpars`, which is still needed for remnant assignment in BSE.