### PR TITLE
remnant and co core mass issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 *.swp
 *.o
 *.mod
+*.txt
+.DS_Store
+fort.99
+metisse
+output/evolve*
+.gitignore

--- a/main.input
+++ b/main.input
@@ -4,12 +4,12 @@
 
 &SSE_input_controls
 
-initial_Z = 0.02
+initial_Z = 1.23d-4
 
 max_age = 2.0d4   !max age in Myrs
 
-number_of_tracks = 100
-min_mass = 0.3
+number_of_tracks = 1
+min_mass = 57.5
 max_mass = 100.0
 sampling_scheme = 'Kroupa2001'
 

--- a/main.input
+++ b/main.input
@@ -4,12 +4,12 @@
 
 &SSE_input_controls
 
-initial_Z = 1.23d-4
+initial_Z = 0.02
 
 max_age = 2.0d4   !max age in Myrs
 
 number_of_tracks = 1
-min_mass = 57.5
+min_mass = 0.3
 max_mass = 100.0
 sampling_scheme = 'Kroupa2001'
 

--- a/metisse.input
+++ b/metisse.input
@@ -3,9 +3,9 @@
 
 &METISSE_input_controls
 
-METALLICITY_DIR = '/Users/poojan/stellar_tracks/MESA/METISSE_INPUT_FILES/Hydrogen/'
+METALLICITY_DIR = '/Users/poojan/stellar_tracks/MESA/gaia/GaiaBH3-eeps/hydrogen/w_00/p15_115/'
             
-METALLICITY_DIR_HE = '/Users/poojan/stellar_tracks/MESA/METISSE_INPUT_FILES/Helium/'
+METALLICITY_DIR_HE = '/Users/poojan/stellar_tracks/MESA/gaia/GaiaBH3-eeps/helium/w_00/p15_115/'
 
 verbose = .true.
 

--- a/metisse.input
+++ b/metisse.input
@@ -3,9 +3,9 @@
 
 &METISSE_input_controls
 
-METALLICITY_DIR = '/Users/poojan/stellar_tracks/MESA/gaia/GaiaBH3-eeps/hydrogen/w_00/p15_115/'
+METALLICITY_DIR = '/Users/poojan/stellar_tracks/MESA/METISSE_INPUT_FILES/Hydrogen/'
             
-METALLICITY_DIR_HE = '/Users/poojan/stellar_tracks/MESA/gaia/GaiaBH3-eeps/helium/w_00/p15_115/'
+METALLICITY_DIR_HE = '/Users/poojan/stellar_tracks/MESA/METISSE_INPUT_FILES/Helium/'
 
 verbose = .true.
 

--- a/src/METISSE_hrdiag.f90
+++ b/src/METISSE_hrdiag.f90
@@ -93,9 +93,9 @@
                 
                 j_bagb = min(t% ntrack, TA_cHeB_EEP)
                 Mcbagb = t% tr(i_he_core, j_bagb)
-                mc_max = MAX(M_ch,0.773* Mcbagb-0.35)
+                ! mc_max = MAX(M_ch,0.773* Mcbagb-0.35)
 
-                if (check_remnant_phase(t% pars, mc_max)) has_become_remnant = .true.
+                 has_become_remnant  = check_remnant_phase(t% pars)
             
             
             ELSEIF (check_ge(t% pars% core_mass,t% pars% mass)) THEN
@@ -148,12 +148,16 @@
     ! Stripped/ naked helium stars phase 7:9
     IF(t% pars% phase >= He_MS .and. t% pars% phase <=He_GB) THEN
         if (use_sse_NHe) then
+            ! sse formulae for naked helium stars
             call evolve_after_envelope_loss(t,zpars(10))
             Mcbagb = t% zams_mass
             mc_max = max_core_mass_he(t% pars% mass, Mcbagb)
             
             if(t% pars% phase >He_MS) then
-                if(check_remnant_phase(t% pars, mc_max)) has_become_remnant = .true.
+                if ((t% pars% core_mass >=mc_max) .or. (abs(mc_max-t% pars% core_mass)<tiny)) then
+                    t% pars% core_mass = mc_max
+                    has_become_remnant  = check_remnant_phase(t% pars)
+                endif
             endif
             
             if (has_become_remnant .eqv..false.) then
@@ -189,8 +193,8 @@
                 
                 j_bagb = min(t% ntrack, TAMS_HE_EEP)
                 Mcbagb = t% tr(i_mass, j_bagb)
-                mc_max = MAX(M_ch,0.773* Mcbagb-0.35)
-                if (check_remnant_phase(t% pars, mc_max)) has_become_remnant = .true.
+                ! mc_max = MAX(M_ch,0.773* Mcbagb-0.35)
+                has_become_remnant  = check_remnant_phase(t% pars)
             else
                 ! Calculate mass and radius of convective envelope, and envelope gyration radius.
                 if (t% pars% core_radius<0) CALL calculate_rc(t,tscls,zpars,t% pars% core_radius)

--- a/src/METISSE_hrdiag.f90
+++ b/src/METISSE_hrdiag.f90
@@ -34,9 +34,6 @@
     else
         t => tarr(idd)
     endif
-
-
-    
     
     debug = .false.
 !   if ((id == 1).and. kw<=10 )debug = .true.

--- a/src/defaults/metisse_defaults.inc
+++ b/src/defaults/metisse_defaults.inc
@@ -62,5 +62,5 @@
     ! It is important if input tracks do not contain this phase
     ! but can be used regardless.
 
-    construct_postagb_track = .true.
+    construct_postagb_track = .false.
 

--- a/src/interp_support.f90
+++ b/src/interp_support.f90
@@ -25,7 +25,7 @@ module interp_support
         integer:: i, j, k, mlo, mhi, nt, age_col, start
         integer, allocatable:: eeps(:), excl_cols(:)
         
-        debug_mass = .false.
+        debug_mass = .true.
 !        if(t% is_he_track)debug_mass = .true.
 
         if (debug_mass) print*, 'in interpolate_mass',t% initial_mass, t% pars% phase

--- a/src/interp_support.f90
+++ b/src/interp_support.f90
@@ -25,7 +25,7 @@ module interp_support
         integer:: i, j, k, mlo, mhi, nt, age_col, start
         integer, allocatable:: eeps(:), excl_cols(:)
         
-        debug_mass = .true.
+        debug_mass = .false.
 !        if(t% is_he_track)debug_mass = .true.
 
         if (debug_mass) print*, 'in interpolate_mass',t% initial_mass, t% pars% phase
@@ -855,12 +855,10 @@ module interp_support
     subroutine save_values(new_line, pars)
         type(star_parameters):: pars
         real(dp), intent (in):: new_line(:,:)
-        real(dp):: lim_R
-        real(dp):: env_mass
-        real(dp):: sgn
+        real(dp):: lim_R, env_mass, sgn
 
         pars% mass = new_line(i_mass, 1)
-        pars% McHe = new_line(i_he_core, 1)
+        pars% McHe = new_line(i_he_core, 1)            
         pars% McCO = new_line(i_co_core, 1)
         pars% log_L = new_line(i_logL, 1)
         pars% luminosity = 10**pars% log_L

--- a/src/remnant_support.f90
+++ b/src/remnant_support.f90
@@ -35,25 +35,15 @@
         real(dp) :: mc_max,mc_threshold
         
         check_remnant_phase = .false.
-        mc_threshold = pars% core_mass
         
-        if (pars% phase <= TPAGB) then       !without envelope loss
-            !mc = MAX(mc_max,mc_threshold)
-            !mc_max = MIN(pars% mass,mc_max)
-            mc_threshold = pars% McCO
-        elseif (pars% phase >= He_MS) then
-            mc_threshold = pars% core_mass
-        else
-            return
-        endif
-
-        if (mc_max<=0.d0 .or. mc_threshold<=0.d0) then
+        if ((pars% mass > very_low_mass_limit) .and. (pars% core_mass<tiny)) then
             write(UNIT=err_unit,fmt=*)"METISSE error: non-positive core mass",mc_max, mc_threshold
             code_error = .true.
             !assigning an ad-hoc non-zero core mass so the code doesn't break
-            !TODO: fix very low-mass stars that form hewd and may get caught in this
             mc_threshold = 0.7*pars% McHe
             mc_max = mc_threshold
+        else
+            mc_threshold = pars% core_mass
         endif
         
         if(mc_threshold>=mc_max .or. abs(mc_max-mc_threshold)<tiny .or. end_of_file)then

--- a/src/remnant_support.f90
+++ b/src/remnant_support.f90
@@ -3,8 +3,6 @@
     use sse_support
     implicit none
     
-    logical :: end_of_file, debug_rem
-
     !flags to be used while making decision for which method to use
     !for calculating properties of remnnants: neutron stars and black holes
     integer, parameter :: original_SSE = 0
@@ -26,15 +24,17 @@
     integer :: wd_flag = 0
     integer :: ec_flag = 0
     integer :: if_flag = 0
+
+    logical :: end_of_file
+    logical :: debug_rem = .false.
+
     contains
     
     logical function check_remnant_phase(pars,mc_max)
         type(star_parameters) :: pars
         real(dp) :: mc_max,mc_threshold
-
-        debug_rem = .false.
-        check_remnant_phase = .false.
         
+        check_remnant_phase = .false.
         mc_threshold = pars% core_mass
         
         if (pars% phase <= TPAGB) then       !without envelope loss

--- a/src/remnant_support.f90
+++ b/src/remnant_support.f90
@@ -36,7 +36,7 @@
         
         check_remnant_phase = .false.
         
-        if ((pars% mass > very_low_mass_limit) .and. (pars% core_mass<tiny)) then
+        if ((pars% phase >0) .and. (pars% core_mass<tiny)) then
             write(UNIT=err_unit,fmt=*)"METISSE error: non-positive core mass",mc_max, mc_threshold
             code_error = .true.
             !assigning an ad-hoc non-zero core mass so the code doesn't break

--- a/src/remnant_support.f90
+++ b/src/remnant_support.f90
@@ -26,7 +26,7 @@
     integer :: if_flag = 0
 
     logical :: end_of_file
-    logical :: debug_rem = .true.
+    logical :: debug_rem = .false.
 
     contains
     

--- a/src/remnant_support.f90
+++ b/src/remnant_support.f90
@@ -26,37 +26,24 @@
     integer :: if_flag = 0
 
     logical :: end_of_file
-    logical :: debug_rem = .false.
+    logical :: debug_rem = .true.
 
     contains
     
-    logical function check_remnant_phase(pars,mc_max)
+    logical function check_remnant_phase(pars)
         type(star_parameters) :: pars
-        real(dp) :: mc_max,mc_threshold
-        
-        check_remnant_phase = .false.
-        
+
+        check_remnant_phase = .true.
+
+        pars% core_mass = pars% McCO
         if ((pars% phase >0) .and. (pars% core_mass<tiny)) then
-            write(UNIT=err_unit,fmt=*)"METISSE error: non-positive core mass",mc_max, mc_threshold
-            code_error = .true.
+            write(UNIT=err_unit,fmt=*)"METISSE error: non-positive core mass",pars% core_mass
+            if (front_end/=COSMIC) code_error = .true.
             !assigning an ad-hoc non-zero core mass so the code doesn't break
-            mc_threshold = 0.7*pars% McHe
-            mc_max = mc_threshold
-        else
-            mc_threshold = pars% core_mass
+            pars% core_mass = 0.75*pars% McHe
         endif
-        
-        if(mc_threshold>=mc_max .or. abs(mc_max-mc_threshold)<tiny .or. end_of_file)then
-            !mc = MIN(mc_max,mc_threshold)
-            pars% core_mass = mc_threshold
-            pars% age_old = pars% age
-            check_remnant_phase = .true.
-            if (debug_rem) then
-                print*, "check_remnant_phase is true"
-                print*, "mass, core_mass, McCO, mc_max"
-                print*, pars% mass, pars% core_mass, pars% McCO, mc_max
-            end if
-        endif
+        pars% age_old = pars% age
+        if (debug_rem) print*, 'Remnant: mass, core_mass ', pars% mass, pars% McHe, pars% McCO
         
         end function check_remnant_phase
         
@@ -118,7 +105,7 @@
                     call check_ns_bh(pars)
                 endif
             endif
-        if (debug_rem .and. pars% phase>9) print*,"In remnant phase", phase_label(pars% phase+1)," , mass", pars% mass
+        if (debug_rem .and. pars% phase>9) print*,"Assigned remnant phase ", phase_label(pars% phase+1)
         
     end subroutine assign_remnant_METISSE
 
@@ -217,7 +204,7 @@
         pars% age = 0.0
 
         call evolve_white_dwarf(pars)
-        if (debug_rem) print*, "Remnant phase = ", phase_label(pars% phase+1), ", mass =", pars% mass
+        if (debug_rem) print*, phase_label(pars% phase+1), ", mass =", pars% mass
     end subroutine
 
     subroutine check_IFMR(mass, mc)
@@ -243,7 +230,7 @@
         if (debug_rem) print*,"In CCSNe section",pars% core_mass,pars% mass
         pars% age = 0.0
         Mrem = calculate_NSBH_mass(pars% core_mass,pars% mass)
-        if(debug_rem) print*, "Mrem= ", Mrem
+        if(debug_rem) print*, "Mrem = ", Mrem
 
         if(Mrem <= Max_NS_mass)then
             pars% phase = NS       !Zero-age Neutron star
@@ -255,7 +242,7 @@
             call evolve_black_hole(pars)
 
         endif
-        if (debug_rem) print*, "NS/BH mass from", trim(BHNS_mass_scheme),"scheme = ",pars% mass
+        if (debug_rem) print*, "NS/BH mass from ", trim(BHNS_mass_scheme)," scheme = ",pars% mass
     end subroutine
 
     real(dp) function calculate_NSBH_mass(Mc,Mt) result(Mrem)

--- a/src/z_support.f90
+++ b/src/z_support.f90
@@ -1014,9 +1014,10 @@ module z_support
     end subroutine set_star_type_from_label
 
     subroutine check_tracks(num_tracks)
-        integer :: n, abs_min_ntrack
-        real(dp) :: co_core, he_core, min_val
+        
         integer, intent(out):: num_tracks
+        integer :: n, abs_min_ntrack,loc
+        real(dp) :: co_core, he_core, min_val
         real(dp), allocatable, dimension(:) :: core_mass
         real(dp), allocatable, dimension(:) :: sgn
 
@@ -1028,9 +1029,11 @@ module z_support
 
         do n = 1,size(xa)
             xa(n)% complete = .true.
-            co_core = xa(n)% tr(i_co_core,xa(n)% ntrack)
-            he_core = xa(n)% tr(i_he_core,xa(n)% ntrack)
-            min_val = 0.01* xa(n)% tr(i_mass,xa(n)% ntrack)
+            loc = min(maxloc(xa(n)% tr(i_co_core,:),dim=1),xa(n)% ntrack)
+            print*, xa(n)% initial_mass, xa(n)% ntrack, loc
+            co_core = xa(n)% tr(i_co_core,loc)
+            he_core = xa(n)% tr(i_he_core,loc)
+            min_val = 0.01* xa(n)% tr(i_mass,loc)
             if (xa(n)% star_type == star_high_mass) then
                 if (co_core< min_val .or. he_core< min_val .or. he_core< co_core) then
                 write(out_unit,*)'skipping ',xa(n)% filename, 'REASON: invalid core mass',co_core, he_core, xa(n)% initial_mass

--- a/src/z_support.f90
+++ b/src/z_support.f90
@@ -1034,22 +1034,34 @@ module z_support
             abs_min_ntrack = TAMS_EEP
             if(xa(n)% is_he_track) abs_min_ntrack = TAMS_HE_EEP
             if (xa(n)% ntrack < abs_min_ntrack) then
-                write(out_unit,*)'skipping ',xa(n)% filename, 'REASON: length < TAMS_EEP',xa(n)% ntrack
+                write(out_unit,*)'skipping ',trim(xa(n)% filename)
+                write(out_unit,*) 'REASON: length < TAMS_EEP',xa(n)% ntrack, xa(n)% initial_mass
                 xa(n)% complete = .false.
                 cycle
             endif
 
-            ! next check for core masses 
-            loc = xa(n)% ntrack !min(maxloc(xa(n)% tr(i_co_core,:),dim=1),xa(n)% ntrack)
-            co_core = xa(n)% tr(i_co_core,loc)
-            he_core = xa(n)% tr(i_he_core,loc)
-            min_val = 0.01* xa(n)% tr(i_mass,loc)
+            ! next check for core masses for massive stars
             if (xa(n)% star_type == star_high_mass) then
+                loc = xa(n)% ntrack 
+                co_core = xa(n)% tr(i_co_core,loc)
+                he_core = xa(n)% tr(i_he_core,loc)
+                min_val = 0.01* xa(n)% tr(i_mass,loc)
                 if (co_core< min_val .or. he_core< min_val .or. he_core< co_core) then
-                    write(out_unit,*)'skipping ',xa(n)% filename, 'REASON: invalid core mass'
-                    write(out_unit,*) xa(n)% initial_mass, he_core, co_core
-                    xa(n)% complete = .false.
-                    cycle
+                    ! workaround to include tracks with decaying co core  
+                    ! it's possibly a numerical issue- tracks should take care of this 
+                    ! check if co core was ever formed 
+                    loc = maxloc(xa(n)% tr(i_co_core,:),dim=1)
+                    co_core = xa(n)% tr(i_co_core,loc)
+                    he_core = xa(n)% tr(i_he_core,loc)
+                    min_val = 0.01* xa(n)% tr(i_mass,loc)
+                    if (co_core< min_val .or. he_core< min_val .or. he_core< co_core) then
+                        write(out_unit,*)'skipping ',trim(xa(n)% filename)
+                        write(out_unit,*)'REASON: invalid core mass', xa(n)% initial_mass, he_core, co_core
+                        xa(n)% complete = .false.
+                        cycle
+                    else
+                        xa(n)% tr(i_co_core,loc:xa(n)% ntrack) = co_core
+                    endif
                 endif
             endif
             

--- a/src/z_support.f90
+++ b/src/z_support.f90
@@ -1029,28 +1029,28 @@ module z_support
 
         do n = 1,size(xa)
             xa(n)% complete = .true.
-            loc = min(maxloc(xa(n)% tr(i_co_core,:),dim=1),xa(n)% ntrack)
-            print*, xa(n)% initial_mass, xa(n)% ntrack, loc
+
+            ! first check if tracks at least have MS
+            abs_min_ntrack = TAMS_EEP
+            if(xa(n)% is_he_track) abs_min_ntrack = TAMS_HE_EEP
+            if (xa(n)% ntrack < abs_min_ntrack) then
+                write(out_unit,*)'skipping ',xa(n)% filename, 'REASON: length < TAMS_EEP',xa(n)% ntrack
+                xa(n)% complete = .false.
+                cycle
+            endif
+
+            ! next check for core masses 
+            loc = xa(n)% ntrack !min(maxloc(xa(n)% tr(i_co_core,:),dim=1),xa(n)% ntrack)
             co_core = xa(n)% tr(i_co_core,loc)
             he_core = xa(n)% tr(i_he_core,loc)
             min_val = 0.01* xa(n)% tr(i_mass,loc)
             if (xa(n)% star_type == star_high_mass) then
                 if (co_core< min_val .or. he_core< min_val .or. he_core< co_core) then
-                write(out_unit,*)'skipping ',xa(n)% filename, 'REASON: invalid core mass',co_core, he_core, xa(n)% initial_mass
+                    write(out_unit,*)'skipping ',xa(n)% filename, 'REASON: invalid core mass'
+                    write(out_unit,*) xa(n)% initial_mass, he_core, co_core
                     xa(n)% complete = .false.
                     cycle
                 endif
-            endif
-
-            if (xa(n)% ntrack< get_min_ntrack(xa(n)% star_type, xa(n)% is_he_track)) then
-                abs_min_ntrack = TAMS_EEP
-                if(xa(n)% is_he_track) abs_min_ntrack = TAMS_HE_EEP
-                if (xa(n)% ntrack < abs_min_ntrack) then
-                    write(out_unit,*)'skipping ',xa(n)% filename, 'REASON: length < TAMS_EEP',xa(n)% ntrack
-                    xa(n)% complete = .false.
-                    cycle
-                endif
-            
             endif
             
             ! for complete tracks, make logcolumns if need be


### PR DESCRIPTION
1. Set construct_postagb_track to false by default since most tracks have post agb phase. 
2. The sse check for remnant formation was not really getting applied unless for SSE naked helium stars. Cleaned up the code to properly reflect this. 
3. Added a workaround for input tracks where the CO core mass was decaying to zero due to numerical issues. Ideally, input tracks themselves should take care of this. 