### PR TITLE
fixed core mass error for very low mass stars

### DIFF
--- a/src/METISSE_hrdiag.f90
+++ b/src/METISSE_hrdiag.f90
@@ -42,7 +42,6 @@
     if (debug) print*, '-----------HRDIAG-------------'
     if (debug) print*,"started hrdiag",mt,mc,aj,tn,kw,id,t% post_agb
 
-    end_of_file = .false. !this is just the end of eep track
     has_become_remnant = .false.
     mc_max= 0.d0
         
@@ -85,15 +84,19 @@
                 !check if have reached the end of the eep track
                 if (debug)print*,"end of file:aj,tn ",t% pars% age,t% times(11),t% times(max(kw,1))
                 if (kw<5) call check_early_end(t,dt_hold,id)
-
-                end_of_file = .true.
                 
                 j_bagb = min(t% ntrack, TA_cHeB_EEP)
                 Mcbagb = t% tr(i_he_core, j_bagb)
                 ! mc_max = MAX(M_ch,0.773* Mcbagb-0.35)
 
-                 has_become_remnant  = check_remnant_phase(t% pars)
-            
+                t% pars% core_mass = t% pars% McCO
+                if ((t% initial_mass.gt.very_low_mass_limit) .and. (t% pars% core_mass<tiny)) then
+                    write(UNIT=err_unit,fmt=*)"METISSE error: non-positive core mass",t% pars% core_mass
+                    code_error = .true.
+                    !assigning an ad-hoc non-zero core mass so the code doesn't break
+                    t% pars% core_mass = 0.75*t% pars% McHe
+                endif
+                has_become_remnant = .true.
             
             ELSEIF (check_ge(t% pars% core_mass,t% pars% mass)) THEN
                 !check if envelope has been lost
@@ -150,10 +153,11 @@
             Mcbagb = t% zams_mass
             mc_max = max_core_mass_he(t% pars% mass, Mcbagb)
             
+            ! check for remnant formation for post He-MS stars
             if(t% pars% phase >He_MS) then
                 if ((t% pars% core_mass >=mc_max) .or. (abs(mc_max-t% pars% core_mass)<tiny)) then
                     t% pars% core_mass = mc_max
-                    has_become_remnant  = check_remnant_phase(t% pars)
+                    has_become_remnant = .true.
                 endif
             endif
             
@@ -186,12 +190,12 @@
             if (check_ge(t% pars% age,t% times(11)) .or. (t% pars% core_mass.ge.t% pars% mass)) then
                 !have reached the end of the eep track; self explanatory
                 if (debug) print*,"end of file:aj,tn ",t% pars% age,t% tr(i_he_age,t% ntrack),t% times(kw)
-                end_of_file = .true.
                 
                 j_bagb = min(t% ntrack, TAMS_HE_EEP)
                 Mcbagb = t% tr(i_mass, j_bagb)
                 ! mc_max = MAX(M_ch,0.773* Mcbagb-0.35)
-                has_become_remnant  = check_remnant_phase(t% pars)
+                t% pars% core_mass = t% pars% McCO
+                has_become_remnant = .true.
             else
                 ! Calculate mass and radius of convective envelope, and envelope gyration radius.
                 if (t% pars% core_radius<0) CALL calculate_rc(t,tscls,zpars,t% pars% core_radius)
@@ -205,6 +209,7 @@
     ! remnants phases 10:15
     IF(has_become_remnant) THEN
 !        print*, 'star',id,'is remnant',t% pars% mass,mcbagb,t% pars% core_mass
+        t% pars% age_old = t% pars% age
         t% star_type = remnant
         if (front_end <= main .or. front_end == BSE .or. front_end ==AMUSE) then
             if(t% pars% phase /= HeWD) then

--- a/src/remnant_support.f90
+++ b/src/remnant_support.f90
@@ -24,89 +24,70 @@
     integer :: wd_flag = 0
     integer :: ec_flag = 0
     integer :: if_flag = 0
-
-    logical :: end_of_file
     logical :: debug_rem = .false.
 
     contains
-    
-    logical function check_remnant_phase(pars)
-        type(star_parameters) :: pars
 
-        check_remnant_phase = .true.
+    subroutine check_early_end(t,dt_hold,id)
+        real(dp) :: dt_hold
+        type(track), pointer :: t
+        integer :: id
 
-        pars% core_mass = pars% McCO
-        if ((pars% phase >0) .and. (pars% core_mass<tiny)) then
-            write(UNIT=err_unit,fmt=*)"METISSE error: non-positive core mass",pars% core_mass
-            if (front_end/=COSMIC) code_error = .true.
-            !assigning an ad-hoc non-zero core mass so the code doesn't break
-            pars% core_mass = 0.75*pars% McHe
-        endif
-        pars% age_old = pars% age
-        if (debug_rem) print*, 'Remnant: mass, core_mass ', pars% mass, pars% McHe, pars% McCO
-        
-        end function check_remnant_phase
-        
-        subroutine check_early_end(t,dt_hold,id)
-            real(dp) :: dt_hold
-            type(track), pointer :: t
-            integer :: id
+        if (t% ierr/=0) return
 
-            if (t% ierr/=0) return
-
-            if ((t% initial_mass.gt.very_low_mass_limit).and. (dt_hold.le.t% pars% dt).and.(t% reju.eqv. .false.)) then
-                write(UNIT=err_unit,fmt=*) 'WARNING: Early end of file at phase, mass and id',&
-                t% pars% phase,t% initial_mass,id,t% reju
-                t% ierr = -1
+        if ((t% initial_mass.gt.very_low_mass_limit).and. (dt_hold.le.t% pars% dt).and.(t% reju.eqv. .false.)) then
+            write(UNIT=err_unit,fmt=*) 'WARNING: Early end of file at phase, mass and id',&
+            t% pars% phase,t% initial_mass,id,t% reju
+            t% ierr = -1
 !                    call stop_code
-            endif
-                
-        end subroutine check_early_end
-                
-        
-        subroutine assign_remnant_METISSE(pars, mcbagb)
-            implicit none
-            type(star_parameters) :: pars
-            real(dp) :: Mcbagb
+        endif
+            
+    end subroutine check_early_end
+            
+    
+    subroutine assign_remnant_METISSE(pars, mcbagb)
+        implicit none
+        type(star_parameters) :: pars
+        real(dp) :: Mcbagb
 
-            !Mup_core, Mec_core are calculated in set_zparmeters routine of zfuncs
-            if(pars% core_mass < M_ch)then
-                if(mcbagb< Mup_core)then
-                    pars% phase = CO_WD        !Zero-age Carbon/Oxygen White Dwarf
+        !Mup_core, Mec_core are calculated in set_zparmeters routine of zfuncs
+        if(pars% core_mass < M_ch)then
+            if(mcbagb< Mup_core)then
+                pars% phase = CO_WD        !Zero-age Carbon/Oxygen White Dwarf
+            else
+                if (ec_flag>0 .and. pars% McCO >= 1.372)then
+                    !electron-capture collapse of an ONe core
+                    !1.372<= mc< 1.44
+                    pars% phase = NS
+                    call initialize_ECSNe(pars)
+                    if (debug_rem) print*,"ECSNe I: Mc< Mch, Mcbagb>Mup"
                 else
-                    if (ec_flag>0 .and. pars% McCO >= 1.372)then
-                     !electron-capture collapse of an ONe core
-                     !1.372<= mc< 1.44
-                        pars% phase = NS
-                        call initialize_ECSNe(pars)
-                        if (debug_rem) print*,"ECSNe I: Mc< Mch, Mcbagb>Mup"
-                    else
-                        pars% phase = ONeWD    !Zero-age Oxygen/Neon White Dwarf
-                    endif
+                    pars% phase = ONeWD    !Zero-age Oxygen/Neon White Dwarf
                 endif
-            else !(mc>mch)
-                !supernova 
-                if(Mcbagb < Mup_core)then
-                    ! Star is not massive enough to ignite C burning.
-                    ! so no remnant is left after the SN
-                    pars% phase = Massless_REM
-                    call initialize_massless_rem(pars)
+            endif
+        else !(mc>mch)
+            !supernova 
+            if(Mcbagb < Mup_core)then
+                ! Star is not massive enough to ignite C burning.
+                ! so no remnant is left after the SN
+                pars% phase = Massless_REM
+                call initialize_massless_rem(pars)
 
-                else if(Mcbagb>= Mup_core .and. Mcbagb<= Mec_core)then
-                    !Check for an electron-capture collapse of an ONe core.
-                    if(ec_flag>0) then
-                        pars% phase = NS
-                        call initialize_ECSNe(pars)
-                        if (debug_rem) print*,"ECSNe II: Mc> Mch, Mup< Mbagb< Mec"
-                    else
-                        call check_ns_bh(pars)
-                    endif
+            else if(Mcbagb>= Mup_core .and. Mcbagb<= Mec_core)then
+                !Check for an electron-capture collapse of an ONe core.
+                if(ec_flag>0) then
+                    pars% phase = NS
+                    call initialize_ECSNe(pars)
+                    if (debug_rem) print*,"ECSNe II: Mc> Mch, Mup< Mbagb< Mec"
                 else
                     call check_ns_bh(pars)
                 endif
+            else
+                call check_ns_bh(pars)
             endif
+        endif
         if (debug_rem .and. pars% phase>9) print*,"Assigned remnant phase ", phase_label(pars% phase+1)
-        
+    
     end subroutine assign_remnant_METISSE
 
     subroutine post_agb_parameters(t,old_phase)


### PR DESCRIPTION
There is a check in the code for non-zero co core mass during remnant formation. That check was being hit (as an error) for very low mass stars that don't form CO cores. Fixed that by adding a check for the mass of the star. 