### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,12 +9,12 @@ build:
   os: "ubuntu-24.04"
   tools:
     python: "miniconda3-3.12-24.9"
-  jobs:
-    post_install:
-      - make -C docs html
+#   jobs:
+#     post_install:
+#       - make -C docs html
     
-conda:
-  environment: environment.yml
+# conda:
+#   environment: environment.yml
   
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -32,6 +32,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,8 @@ version: 2
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "miniconda3-3.12-24.9"
+    python: "3.12"
+    # python: "miniconda3-3.12-24.9"
 #   jobs:
 #     post_install:
 #       - make -C docs html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,4 +7,3 @@ nbsphinx>=0.8.6
 lxml_html_clean
 pandoc<3.0.0
 ipykernel 
-numpy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,7 +106,7 @@ html_css_files = [
 # set default highlighting language
 highlight_language = 'console'
 
-nbsphinx_execute = 'always' 
+nbsphinx_execute = 'never' 
 nbsphinx_allow_errors = True
 exclude_patterns = ['**.ipynb_checkpoints']
 


### PR DESCRIPTION
While the example notebook was being executed through Read the Docs, errors were encountered in certain cells because the paths to the tracks required for running Metisse were not found. 
The notebook execution has been modified so that these cells are skipped when the documentation is rendered through Read the Docs. 
This also removes the need for a conda environment, allowing a return to using requirements.txt.