### PR TITLE
Re-Implement Envelope Stripping Check in METISSE_hrdiag.f90

### DIFF
--- a/src/METISSE_hrdiag.f90
+++ b/src/METISSE_hrdiag.f90
@@ -16,7 +16,7 @@
     
     integer :: kw,i,idd,j_bagb,old_phase
     real(dp) :: rg,rzams,rtms
-    real(dp) :: Mcbagb, mc_max,HeI_time,dt_hold
+    real(dp) :: Mcbagb, mc_max,HeI_time,dt_hold,env_frac
     real(dp) :: bhspin ! only for cosmic
     type(star_parameters) :: old_pars
 
@@ -51,6 +51,7 @@
     dt_hold = aj - t% pars% age
     if (aj/=aj) aj = t% pars% age
     t% pars% age = aj
+    env_frac = MAX((mt - mc)/mt,0.d0)
     
     IF (t% pars% phase<=TPAGB) THEN
         if (t% post_agb) then
@@ -103,7 +104,7 @@
                 
                 has_become_remnant = .true.
             
-            ELSEIF (check_ge(t% pars% core_mass,t% pars% mass)) THEN
+            ELSEIF (env_frac<1.d-8.and.t% pars% phase >= HG) THEN
                 !check if envelope has been lost
 
                 if (debug)print*,"envelope lost at",t% pars% age,t% pars% phase,t% pars% mass,t% pars% core_mass


### PR DESCRIPTION
Hi,

This PR attempts to solve two distinct problems we discovered at the same time.

1. Systems evolved with COSMIC-METISSE don't reliably switch to helium tracks when subject to extreme wind mass loss. This is most apparent at high (solar-like) metallicity, where high-mass stars can lose their entire envelope whilst still on the main sequence.
2. Systems which switch onto pure-helium tracks experience a different mass loss rate and radial evolution than their "stripped" hydrogen star progenitors. This is a result of differences between the hydrogen & helium tracks, and it can change the final CO core mass by ~1-3 Msun, or up to 10 Msun for ZAMS masses > 100 Msun.

I was able to resolve this by changing the test which triggers the envelope stripping. The current implementation checks if `t% pars% core_mass >= t% pars% mass`. This behaves inconsistently without a companion to strip down the envelope. I hypothesize that this is because MESA tracks that are effectively stripped are not guaranteed to lose "all" their envelope, as even a single non-"core" layer will cause this check to fail.

The new implementation instead checks if `(mt-mc)/mt < 1d-8`, where `mt=t% pars% mass` and `mc=t% pars% core_mass`. `1d-8` was chosen arbitrarily.

To address the second issue I add a condition to forbid switching to helium tracks until the end of main sequence. This solves the mass discrepancy for stars which self-strip on the main sequence, but those which strip later on may need a more detailed treatment. Cheers.

<img width="2100" height="900" alt="Z1 40e-02_core_mass_kstar_pre_SN" src="https://github.com/user-attachments/assets/8617d9b5-4ee1-4d41-aee9-23565e82b5d1" />
